### PR TITLE
Änderungen in der Formelübersicht: Spaltenüberschriften, Einheiten mi…

### DIFF
--- a/src/conf/info.tex
+++ b/src/conf/info.tex
@@ -1,33 +1,34 @@
 \section{Formelübersicht} % Major section
 \subsection{Gleichstrommaschine} % Sub-section
 \begin{tabular}{L{2cm}lR{2cm}}
-	$I_A$  &Ankerstrom  &[$A$]\\
-	$U_A$ &Ankerspannung & [$V$]\\
-	$R_A$  &Ankerwiderstand &[$ \Omega $] \\
-	$L_A$  &Ankerinduktivität &[$H$]\\
-	$\Psi_A$ &Ankerfluss & [$Vs$]\\
-	$I_F$ & Feldstrom & [$A$]\\
-	$U_F$ & Feldspannung & [$V$]\\
-	$R_F$ & Feldwiderstand & [$R$]\\
-	$L_F$ & Feldinduktivität & [$H$]\\
-	$\Psi_F$ &Feldfluss & [$Vs$]\\
-	$U_i$ &Induzierte Spannung & [$V$]\\
-	$\Psi_M$ &Permanentmagnetfluss & [$Vs$]\\
-	$k^{'} \phi$ &Spannungskonstante & [$Vs$]\\
-	$\Omega_m$ &Winkelgeschwindigkeit Motor & [$1/s$]\\
-	$\Omega_{m,0}$ &Leerlauf Winkelgeschwindigkeit Motor & [$1/s$]\\
-	$\Omega_{m,N}$ &Nennwinkelgeschwindigkeit Motor & [$1/s$]\\
-	$\Theta_m$ &Trägheitsmoment Motor & [$kg \, m^{2}$]\\
-	$M_m$ &Moment Motor & [$N\,m$]\\
-	$M_L$ &Moment Last & [$N\,m$]\\
-	$A_M$ &Fläche Magnet & [$m^{2}$]\\
-	$A_L$ &Fläche Luftspalt & [$m^{2}$]\\
-	$l_M$ &Länge Magnet & [$m$]\\
-	$l_L$ &Länge Luftspalt & [$m$]\\
-	$B_M$ &Flußdichte Magnet & [$T$]\\
-	$B_r$ &Remanenzflußdichte Magnet & [$T$]\\
-	$B_L$ &Flußdichte Luftspalt & [$T$]\\
-	$\mu_0$ &magnetische Feldkonstante & [$V\,s/ (A \, m)$]\\
+    \textbf{Symbol} &\textbf{Bezeichnung} &\textbf{Einheit}\\
+	$I_A$  		&Ankerstrom  			&\si{A}\\
+	$U_A$  		&Ankerspannung 			&\si{V}\\
+	$R_A$  		&Ankerwiderstand 		&\si{\Omega} \\
+	$L_A$		&Ankerinduktivität 		&\si{H}\\
+	$\Psi_A$ 	&Ankerfluss 			&\si{Vs}\\
+	$I_F$ 		&Feldstrom 				&\si{A}\\
+	$U_F$ 		&Feldspannung 			&\si{V}\\
+	$R_F$ 		&Feldwiderstand 		&\si{R}\\
+	$L_F$ 		& Feldinduktivität 		&\si{H}\\
+	$\Psi_F$ 	&Feldfluss 				&\si{Vs}\\
+	$U_i$ 		&Induzierte Spannung 		&\si{V}\\
+	$\Psi_M$ 	&Permanentmagnetfluss 		&\si{Vs}\\
+	$k^{'} \phi$ 	&Spannungskonstante 	&\si{Vs}\\
+	$\Omega_m$ 		&Winkelgeschwindigkeit Motor 			&\si{1/s}\\
+	$\Omega_{m,0}$ 	&Leerlauf Winkelgeschwindigkeit Motor 	&\si{1/s}\\
+	$\Omega_{m,N}$ 	&Nennwinkelgeschwindigkeit Motor 		&\si{1/s}\\
+	$\Theta_m$ 		&Trägheitsmoment Motor 					&\si{kg m^{2}}\\
+	$M_m$ 		&Moment Motor 			&\si{Nm}\\
+	$M_L$ 		&Moment Last 			&\si{Nm}\\
+	$A_M$ 		&Fläche Magnet 			&\si{m^{2}}\\
+	$A_L$ 		&Fläche Luftspalt 		&\si{m^{2}}\\
+	$l_M$ 		&Länge Magnet 			&\si{m}\\
+	$l_L$ 		&Länge Luftspalt 		&\si{m}\\
+	$B_M$ 		&Flussdichte Magnet 	&\si{T}\\
+	$B_r$ 		&Remanenzflussdichte Magnet 	&\si{T}\\
+	$B_L$ 		&Flussdichte Luftspalt 			&\si{T}\\
+	$\mu_0$ 	&magnetische Feldkonstante 		& \si{Vs / Am}\\
 \end{tabular}\\
 \subsubsection{Permanentmagneterregt}
 Ankerfluss
@@ -113,7 +114,7 @@ Statorinduktivität
 \begin{equation}
 	l_s = \frac{3}{2} \cdot l_{strang}
 \end{equation}
-Statorflußverkettungsgleichung
+Statorflussverkettungsgleichung
 \begin{equation}
 	\underline{\Psi}_s = l_s \cdot \underline{i}_s + \underline{\Psi}_M = l_s \cdot \underline{i}_s + |\underline{\Psi}_M | \cdot e^{\jmath \cdot \gamma + \jmath \omega \tau}
 \end{equation}

--- a/src/conf/package.tex
+++ b/src/conf/package.tex
@@ -37,6 +37,8 @@
 
 \usepackage{float} % Allows putting an [H] in \begin{figure} to specify the exact location of the figure
 
+\usepackage{siunitx}
+
 \usepackage{exsheets}%newer than 0.0.21!!!
 \usepackage{tabularx}
 \newcolumntype{L}[1]{>{\raggedright\arraybackslash}p{#1}} % linksbündig mit Breitenangabe


### PR DESCRIPTION
Änderungen in der Formelübersicht: Spaltenüberschriften, Einheiten mit siunitx, Fluß->Fluss.
Hinzufügen von siunitx in conf/package.tex

ACHTUNG, benötigt das siunitx package; sollte in Texlive vorhanden sein, bitte unbedingt selbst testen ob das geht, bei mir ohne Probleme.

Auf Ubuntu gibt es texlive-science (http://packages.ubuntu.com/de/trusty/texlive-science) wo afaik siunitx drinnen ist.

Gegebenenfalls abwägen ob ausreichend kompatibel hinsichtlich Latex bzw. iA vorhandener Pakete.  

Siehe auch #13 